### PR TITLE
fix(utils): 🐛 修复 getCurrentPath 在页面为空时可能报错的问题

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -5,5 +5,5 @@
 export function getCurrentPath() {
   const pages = getCurrentPages()
   const currentPage = pages[pages.length - 1]
-  return currentPage.route || ''
+  return currentPage?.route || ''
 }


### PR DESCRIPTION
<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

无

### 💡 需求背景和解决方案

在部分生命周期较早的场景下，
`getCurrentPages()` 可能返回空数组，
此时 `getCurrentPath` 中访问 `currentPage.route` 会导致报错。

本次修改仅增加安全判断（可选链），
避免在页面为空时访问 `undefined` 属性。

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* 修复了特定条件下可能出现的运行时错误，提升应用稳定性

<!-- end of auto-generated comment: release notes by coderabbit.ai -->