### PR TITLE
fix: preserve GlobalDialog alert button behavior

### DIFF
--- a/src/components/GlobalDialog.vue
+++ b/src/components/GlobalDialog.vue
@@ -27,7 +27,15 @@ watch(() => dialogOptions.value, (newVal) => {
   if (newVal) {
     if (currentPage.value === currentPath) {
       const option = deepClone(newVal)
-      dialog.show(option).then((res) => {
+      const showDialog = option.type === 'confirm'
+        ? dialog.confirm
+        : option.type === 'prompt'
+          ? dialog.prompt
+          : option.type === 'alert'
+            ? dialog.alert
+            : dialog.show
+
+      showDialog(option).then((res) => {
         if (isFunction(option.success)) {
           option.success(res)
         }

--- a/src/composables/useGlobalDialog.ts
+++ b/src/composables/useGlobalDialog.ts
@@ -11,6 +11,52 @@ interface GlobalDialog {
   currentPage: string
 }
 
+function isButtonPropsObject(value: unknown): value is Record<string, any> {
+  return value !== null && CommonUtil.isObj(value)
+}
+
+function normalizeButtonOptions(option: GlobalDialogOptions): GlobalDialogOptions {
+  const next: GlobalDialogOptions = { ...option }
+
+  if (next.confirmButtonText) {
+    next.confirmButtonProps = isButtonPropsObject(next.confirmButtonProps)
+      ? { ...next.confirmButtonProps, text: next.confirmButtonText }
+      : next.confirmButtonText
+  }
+  else if (next.confirmButtonProps === undefined) {
+    next.confirmButtonProps = {}
+  }
+
+  if (next.cancelButtonText) {
+    next.cancelButtonProps = isButtonPropsObject(next.cancelButtonProps)
+      ? { ...next.cancelButtonProps, text: next.cancelButtonText }
+      : next.cancelButtonText
+  }
+
+  if (next.showCancelButton === false) {
+    next.cancelButtonProps = null
+  }
+  else if (next.showCancelButton === true && next.cancelButtonProps === undefined) {
+    next.cancelButtonProps = {}
+  }
+
+  if (isButtonPropsObject(next.confirmButtonProps)) {
+    next.confirmButtonProps = {
+      ...next.confirmButtonProps,
+      round: false,
+    }
+  }
+
+  if (isButtonPropsObject(next.cancelButtonProps)) {
+    next.cancelButtonProps = {
+      ...next.cancelButtonProps,
+      round: false,
+    }
+  }
+
+  return next
+}
+
 export const useGlobalDialog = defineStore('global-Dialog', {
   state: (): GlobalDialog => ({
     dialogOptions: null,
@@ -19,15 +65,7 @@ export const useGlobalDialog = defineStore('global-Dialog', {
   actions: {
     show(option: GlobalDialogOptions | string) {
       this.currentPage = getCurrentPath()
-      this.dialogOptions = {
-        ...(CommonUtil.isString(option) ? { title: option } : option),
-        cancelButtonProps: {
-          round: false,
-        },
-        confirmButtonProps: {
-          round: false,
-        },
-      }
+      this.dialogOptions = normalizeButtonOptions(CommonUtil.isString(option) ? { title: option } : option)
     },
     alert(option: GlobalDialogOptions | string) {
       const DialogOptions = CommonUtil.deepMerge({ type: 'alert' }, CommonUtil.isString(option) ? { title: option } : option) as DialogOptions


### PR DESCRIPTION
<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [x] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

暂无。

### 💡 需求背景和解决方案

GlobalDialog 的全局封装会统一调用 `dialog.show(option)`，并在 `show()` 中直接补充 `cancelButtonProps` 和 `confirmButtonProps`。这会导致 `alert()` 传入的 `showCancelButton: false` 无法隐藏取消按钮，`confirmButtonText` 等快捷配置也无法稳定透传到实际按钮配置。

本次修复：

1. 在写入 Pinia 状态前规范化按钮配置，将 `confirmButtonText` / `cancelButtonText` 合并到对应 button props。
2. 当 `showCancelButton === false` 时保留 `cancelButtonProps: null`，并避免 `null` 被 `CommonUtil.isObj` 误判后重新变成对象。
3. GlobalDialog 组件根据 `option.type` 调用 `dialog.alert` / `dialog.confirm` / `dialog.prompt`，保留 Wot UI 原有类型语义。

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
