### PR TITLE
fix: 🐛 preserve global dialog alert buttons

### DIFF
--- a/src/composables/useGlobalDialog.ts
+++ b/src/composables/useGlobalDialog.ts
@@ -11,6 +11,78 @@ interface GlobalDialog {
   currentPage: string
 }
 
+type DialogType = NonNullable<DialogOptions['type']>
+
+function isButtonPropsObject(value: unknown): value is Record<string, any> {
+  return value !== null && CommonUtil.isObj(value)
+}
+
+function normalizeButtonProps(props: unknown, text?: string) {
+  if (props === null) {
+    return null
+  }
+
+  if (isButtonPropsObject(props)) {
+    return {
+      ...props,
+      ...(text ? { text } : {}),
+      round: false,
+    }
+  }
+
+  if (CommonUtil.isString(props) || text) {
+    return {
+      text: text || props,
+      round: false,
+    }
+  }
+
+  if (props === undefined) {
+    return {
+      round: false,
+    }
+  }
+
+  return props
+}
+
+function withDefaultTypeOptions(option: GlobalDialogOptions, type?: DialogType): GlobalDialogOptions {
+  const next: GlobalDialogOptions = {
+    ...option,
+    ...(type ? { type } : {}),
+  }
+
+  if (next.showCancelButton === undefined) {
+    if (next.type === 'alert') {
+      next.showCancelButton = false
+    }
+    else if (next.type === 'confirm' || next.type === 'prompt') {
+      next.showCancelButton = true
+    }
+  }
+
+  return next
+}
+
+function normalizeDialogOptions(option: GlobalDialogOptions, type?: DialogType): GlobalDialogOptions {
+  const next = withDefaultTypeOptions(option, type)
+
+  next.confirmButtonProps = normalizeButtonProps(next.confirmButtonProps, next.confirmButtonText) as DialogOptions['confirmButtonProps']
+
+  if (next.showCancelButton === false) {
+    next.cancelButtonProps = null
+  }
+  else if (next.showCancelButton === true || next.cancelButtonProps !== undefined || next.cancelButtonText) {
+    next.cancelButtonProps = normalizeButtonProps(next.cancelButtonProps, next.cancelButtonText) as DialogOptions['cancelButtonProps']
+  }
+
+  return next
+}
+
+function normalizeOption(option: GlobalDialogOptions | string, type?: DialogType): GlobalDialogOptions {
+  return normalizeDialogOptions(CommonUtil.isString(option) ? { title: option } : option, type)
+}
+
 export const useGlobalDialog = defineStore('global-Dialog', {
   state: (): GlobalDialog => ({
     dialogOptions: null,
@@ -19,30 +91,19 @@ export const useGlobalDialog = defineStore('global-Dialog', {
   actions: {
     show(option: GlobalDialogOptions | string) {
       this.currentPage = getCurrentPath()
-      this.dialogOptions = {
-        ...(CommonUtil.isString(option) ? { title: option } : option),
-        cancelButtonProps: {
-          round: false,
-        },
-        confirmButtonProps: {
-          round: false,
-        },
-      }
+      this.dialogOptions = normalizeOption(option)
     },
     alert(option: GlobalDialogOptions | string) {
-      const DialogOptions = CommonUtil.deepMerge({ type: 'alert' }, CommonUtil.isString(option) ? { title: option } : option) as DialogOptions
-      DialogOptions.showCancelButton = false
-      this.show(DialogOptions)
+      this.currentPage = getCurrentPath()
+      this.dialogOptions = normalizeOption(option, 'alert')
     },
     confirm(option: GlobalDialogOptions | string) {
-      const DialogOptions = CommonUtil.deepMerge({ type: 'confirm' }, CommonUtil.isString(option) ? { title: option } : option) as DialogOptions
-      DialogOptions.showCancelButton = true
-      this.show(DialogOptions)
+      this.currentPage = getCurrentPath()
+      this.dialogOptions = normalizeOption(option, 'confirm')
     },
     prompt(option: GlobalDialogOptions | string) {
-      const DialogOptions = CommonUtil.deepMerge({ type: 'prompt' }, CommonUtil.isString(option) ? { title: option } : option) as DialogOptions
-      DialogOptions.showCancelButton = true
-      this.show(DialogOptions)
+      this.currentPage = getCurrentPath()
+      this.dialogOptions = normalizeOption(option, 'prompt')
     },
     close() {
       this.dialogOptions = null


### PR DESCRIPTION
<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

暂无。

### 💡 需求背景和解决方案

GlobalDialog 的全局封装会统一调用 `dialog.show(option)`，并在写入状态时补充默认按钮配置。原逻辑会导致 `alert()` 设置的 `showCancelButton: false` 被默认的 `cancelButtonProps` 影响，取消按钮仍然可能显示；同时 `confirmButtonText` / `cancelButtonText` 等快捷配置也没有统一合并到实际按钮配置中。

本次修复：

1. 在 `useGlobalDialog` 内统一规范化 `show` / `alert` / `confirm` / `prompt` 的 dialog options。
2. `alert` 默认隐藏取消按钮，`confirm` / `prompt` 默认显示取消按钮，同时保留调用方显式传入的 `showCancelButton`。
3. 将 `confirmButtonText` / `cancelButtonText` 合并进对应 button props，并在 `showCancelButton === false` 时保留 `cancelButtonProps: null`。
4. 保持 `GlobalDialog.vue` 作为展示层，不在组件内分发不同 dialog 类型。

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充