### PR TITLE
fix: 🐛 上传请求不设置Content-Type为application/json

### DIFF
--- a/src/api/core/instance.ts
+++ b/src/api/core/instance.ts
@@ -12,7 +12,7 @@ export const alovaInstance = createAlova({
   statesHook: vueHook,
   beforeRequest: (method) => {
     // Add content type for POST/PUT/PATCH requests
-    if (['POST', 'PUT', 'PATCH'].includes(method.type)) {
+    if (['POST', 'PUT', 'PATCH'].includes(method.type) && method?.config?.requestType !== 'upload') {
       method.config.headers['Content-Type'] = 'application/json'
     }
 


### PR DESCRIPTION
<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

**问题：** 在 H5 环境下，使用 alova 上传文件时报错

**解决：** 上传文件时，不更改请求头的 `Content-Type`，保持原有的 `multipart/form-data` 格式
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
